### PR TITLE
feat: add scylladb cloud examples

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,9 +31,6 @@ A curated list of awesome ScyllaDB projects, libraries, and tools in various pro
 - **[Getting Started with ScyllaDB Cloud Using Node.js](https://www.scylladb.com/2023/03/02/getting-started-with-scylladb-cloud-using-node-js-part-1/)**: A step-by-step guide to building a simple Node.js application with ScyllaDB Cloud. The tutorial covers setting up the environment, creating a cluster, connecting to the cluster, and performing CRUD operations using JavaScript​ ([ScyllaDB](https://www.scylladb.com/2023/03/02/getting-started-with-scylladb-cloud-using-node-js-part-1/))​.
 - **[IoT App with JavaScript](https://iot.scylladb.com/stable/build-with-javascript.html)**: This tutorial demonstrates building an IoT application that uses ScyllaDB as the backend database. It includes instructions on setting up the database schema, simulating sensor data, and periodically saving data to the database using Node.js​ ([ScyllaDB IoT](https://iot.scylladb.com/stable/build-with-javascript.html))​.
 
-### Clojure
-- **[Alia](https://github.com/mpenet/alia)**: A modern and high performance Cassandra and ScyllaDB client for Clojure, wrapping the Java Driver from DataStax, supporting CQL3, raw queries, prepared statements, synchronous and asynchronous query exectuion, asynchronous interfaces using either **clojure/core.async**, extensible Clojure data types. The driver can be installed from source or using the [Clojars package](https://clojars.org/cc.qbits/alia).
-
 ## Documentation Tools
 
 ### Sphinx

--- a/README.MD
+++ b/README.MD
@@ -31,6 +31,9 @@ A curated list of awesome ScyllaDB projects, libraries, and tools in various pro
 - **[Getting Started with ScyllaDB Cloud Using Node.js](https://www.scylladb.com/2023/03/02/getting-started-with-scylladb-cloud-using-node-js-part-1/)**: A step-by-step guide to building a simple Node.js application with ScyllaDB Cloud. The tutorial covers setting up the environment, creating a cluster, connecting to the cluster, and performing CRUD operations using JavaScript​ ([ScyllaDB](https://www.scylladb.com/2023/03/02/getting-started-with-scylladb-cloud-using-node-js-part-1/))​.
 - **[IoT App with JavaScript](https://iot.scylladb.com/stable/build-with-javascript.html)**: This tutorial demonstrates building an IoT application that uses ScyllaDB as the backend database. It includes instructions on setting up the database schema, simulating sensor data, and periodically saving data to the database using Node.js​ ([ScyllaDB IoT](https://iot.scylladb.com/stable/build-with-javascript.html))​.
 
+### Clojure
+- **[Alia](https://github.com/mpenet/alia)**: A modern and high performance Cassandra and ScyllaDB client for Clojure, wrapping the Java Driver from DataStax, supporting CQL3, raw queries, prepared statements, synchronous and asynchronous query exectuion, asynchronous interfaces using either **clojure/core.async**, extensible Clojure data types. The driver can be installed from source or using the [Clojars package](https://clojars.org/cc.qbits/alia).
+
 ## Documentation Tools
 
 ### Sphinx

--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,7 @@ A curated list of awesome ScyllaDB projects, libraries, and tools in various pro
 
 - **[GocqlX](https://github.com/scylladb/gocqlx)**: A comprehensive Go library for ScyllaDB and Cassandra, featuring CQL query building, ORM functionalities, and migration tools. It simplifies data binding and query execution​ ([GitHub](https://github.com/scylladb/gocqlx))​.
 - **[Scylla Go Driver](https://github.com/scylladb/scylla-go-driver)**: An experimental, high-performance Go driver created by students at the University of Warsaw. It supports token-aware and shard-aware routing, prepared statements, and compression​ ([GitHub](https://github.com/scylladb/scylla-go-driver))​.
+- **[Getting Started with ScyllaDB Cloud Using Go](https://cloud-getting-started.scylladb.com/stable/build-with-golang.html)**: A step-by-step guide to building a simple Go application with ScyllaDB Cloud. The tutorial covers setting up the environment, creating a cluster, connecting to the cluster, and performing CRUD operations using Go.
 
 ### Rust
 
@@ -19,6 +20,7 @@ A curated list of awesome ScyllaDB projects, libraries, and tools in various pro
 - **[Charybdis](https://github.com/nodecosmos/charybdis)**: A Rust ORM for ScyllaDB and Apache Cassandra. It supports automatic migration generation, insertion, and querying of data, making it easier to interact with ScyllaDB in a Rust application​ ([GitHub](https://github.com/nodecosmos/charybdis))​.
 - **[Rust S3 ScyllaDB](https://github.com/javiramos1/rust-s3-scylladb)**: This project provides a real-world example of integrating AWS S3 and ScyllaDB using Rust. It demonstrates how to create ultra-fast REST APIs with Actix Web, manage credentials, ingest data from S3 into ScyllaDB, and perform graph data modeling for fast traversals​ ([GitHub](https://github.com/javiramos1/rust-s3-scylladb))​.
 - **[Scylla Rust UDF](https://github.com/scylladb/scylla-rust-udf)**: A helper library for writing user-defined functions (UDFs) in pure Rust for ScyllaDB. It allows developers to write UDFs that are compiled to WebAssembly (Wasm) and used within ScyllaDB, although it is still an experimental feature​ ([GitHub](https://github.com/scylladb/scylla-rust-udf))​.
+- **[Getting Started with ScyllaDB Cloud Using Rust](https://cloud-getting-started.scylladb.com/stable/build-with-rust.html)**: A step-by-step guide to building a simple Rust application with ScyllaDB Cloud. The tutorial covers setting up the environment, creating a cluster, connecting to the cluster, and performing CRUD operations using Rust.
 
 ### PHP
 


### PR DESCRIPTION
- Add Getting Started with ScyllaDB Cloud using Go;
- Add Getting Started with ScyllaDB Cloud using Rust;